### PR TITLE
feat: update contract with object support

### DIFF
--- a/src/form-plugin-contract.ts
+++ b/src/form-plugin-contract.ts
@@ -38,7 +38,13 @@ interface BooleanProp extends BaseProp {
   type: 'boolean';
 }
 
-export type PropType = ChoiceProp | StringProp | NumberProp | IntegerProp | BooleanProp;
+export type ObjectProp = BaseProp & {
+  type: 'object';
+  placeholder?: string;
+  properties: { [key: string]: PropType };
+};
+
+export type PropType = ChoiceProp | StringProp | NumberProp | IntegerProp | BooleanProp | ObjectProp;
 
 interface PluginDesigner {
   staticProperties?: string[];

--- a/src/form-plugin-zod-contract.ts
+++ b/src/form-plugin-zod-contract.ts
@@ -1,10 +1,12 @@
 import { z } from 'zod';
 
+const defaultObjectValue = z.record(z.lazy(() => z.union([z.string(), z.number(), z.boolean(), defaultObjectValue])));
+
 export const basePropSchema = z.object({
   title: z.string().optional(),
   required: z.boolean().optional(),
   description: z.string().optional(),
-  defaultValue: z.union([z.string(), z.boolean(), z.number()]).optional(),
+  defaultValue: z.union([z.string(), z.boolean(), z.number(), defaultObjectValue]).optional(),
   format: z.string().optional(),
   isValueField: z.boolean().optional(),
 });
@@ -53,12 +55,34 @@ const booleanPropSchema = z.intersection(
   }),
 );
 
+const objectPropSchema = z.intersection(
+  basePropSchema,
+  z.object({
+    type: z.literal('object'),
+    properties: z
+      .lazy(() =>
+        z.record(
+          z.union([
+            choicePropSchema,
+            stringPropSchema,
+            numberPropSchema,
+            integerPropSchema,
+            booleanPropSchema,
+            objectPropSchema,
+          ]),
+        ),
+      )
+      .optional(),
+  }),
+);
+
 const propTypeSchema = z.union([
   choicePropSchema,
   stringPropSchema,
   numberPropSchema,
   integerPropSchema,
   booleanPropSchema,
+  objectPropSchema,
 ]);
 
 const pluginDesignerSchema = z.object({


### PR DESCRIPTION
This PR updates the plugin contract showing that objects are now are supported input type for plugins