### PR TITLE
Align contract with contract used in form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nintex/form-plugin-contract",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nintex/form-plugin-contract",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.20.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nintex/form-plugin-contract",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Nintex",
   "description": "Nintex Forms Plugin Contract",
   "main": "dist/cjs/index.js",

--- a/src/form-plugin-contract.ts
+++ b/src/form-plugin-contract.ts
@@ -81,4 +81,4 @@ export interface PluginContract {
 }
 
 // this is same value is in package.json
-export const PluginContractVersion = '1.0.0';
+export const PluginContractVersion = '1.0.1';

--- a/src/form-plugin-zod-contract.ts
+++ b/src/form-plugin-zod-contract.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
 
+const objectKeyRegex = /^\w+([_]\w+)*$/;
+const nameRegex = /^\w+([\s-_]\w+)*$/;
+
 const defaultObjectValue = z.record(z.lazy(() => z.union([z.string(), z.number(), z.boolean(), defaultObjectValue])));
 
 export const basePropSchema = z.object({
@@ -100,7 +103,7 @@ export const pluginContractSchema = z
   .object({
     version: z.string().nonempty(),
     fallbackDisableSubmit: z.boolean(),
-    controlName: z.string().nonempty(),
+    controlName: z.string().nonempty().regex(nameRegex).max(40),
 
     // optional ones
     pluginAuthor: z.string().optional(),
@@ -120,7 +123,7 @@ export const pluginContractSchema = z
 
     iconUrl: z.string().optional(),
     designer: pluginDesignerSchema.optional(),
-    properties: z.record(propTypeSchema).optional(),
+    properties: z.record(z.string().regex(objectKeyRegex), z.union([propTypeSchema, z.boolean()])).optional(),
     standardProperties: z
       .object({
         fieldLabel: z.boolean().optional(),


### PR DESCRIPTION
In order to use this contract in zinc-core, we need to ensure they are the same. This PR adds in the missing restrictions which are present in zinc-core. 