### PR TITLE
chore: export types to be used in zinc-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nintex/form-plugin-contract",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nintex/form-plugin-contract",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.20.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nintex/form-plugin-contract",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "Nintex",
   "description": "Nintex Forms Plugin Contract",
   "main": "dist/cjs/index.js",

--- a/src/form-plugin-contract.ts
+++ b/src/form-plugin-contract.ts
@@ -81,4 +81,4 @@ export interface PluginContract {
 }
 
 // this is same value is in package.json
-export const PluginContractVersion = '1.0.2';
+export const PluginContractVersion = '1.0.3';

--- a/src/form-plugin-contract.ts
+++ b/src/form-plugin-contract.ts
@@ -1,40 +1,40 @@
-interface BaseProp {
+export interface BaseProp {
   title: string;
-  required?: boolean;
+  required?: string[];
   description?: string;
-  defaultValue?: string | boolean | number;
+  defaultValue?: string | boolean | number | object | undefined;
   format?: string;
   isValueField?: boolean;
 }
 
-type MinimumSize = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+export type MinimumSize = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
-interface StringProp extends BaseProp {
+export interface StringProp extends BaseProp {
   type: 'string';
   minLength?: number;
   maxLength?: number;
 }
 
-interface ChoiceProp extends BaseProp {
+export interface ChoiceProp extends BaseProp {
   type: 'string';
   enum: string[];
   showAsRadio?: boolean;
   verticalLayout?: boolean;
 }
 
-interface NumberProp extends BaseProp {
+export interface NumberProp extends BaseProp {
   type: 'number';
   minimum?: number;
   maximum?: number;
 }
 
-interface IntegerProp extends BaseProp {
+export interface IntegerProp extends BaseProp {
   type: 'integer';
   minimum?: number;
   maximum?: number;
 }
 
-interface BooleanProp extends BaseProp {
+export interface BooleanProp extends BaseProp {
   type: 'boolean';
 }
 

--- a/src/form-plugin-contract.ts
+++ b/src/form-plugin-contract.ts
@@ -1,6 +1,6 @@
 export interface BaseProp {
   title: string;
-  required?: string[];
+  required?: boolean;
   description?: string;
   defaultValue?: string | boolean | number | object | undefined;
   format?: string;


### PR DESCRIPTION
This PR allows the exported types to be used to zinc-core